### PR TITLE
Experimental: Allow shortlists in `marian-scorer` (browsermt)

### DIFF
--- a/src/command/marian_scorer.cpp
+++ b/src/command/marian_scorer.cpp
@@ -8,9 +8,10 @@ int main(int argc, char** argv) {
   using namespace marian;
 
   auto options = parseOptions(argc, argv, cli::mode::scoring);
+  auto task = New<Rescore<Rescorer>>(options);
 
   timer::Timer timer;
-  New<Rescore<Rescorer>>(options)->run();
+  task->run();
   LOG(info, "Total time: {:.5f}s wall", timer.elapsed());
 
   return 0;

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -250,7 +250,7 @@ void ConfigParser::addOptionsModel(cli::CLIWrapper& cli) {
       "Tie all embedding layers and output layer");
   cli.add<bool>("--output-omit-bias",
       "Do not use a bias vector in decoder output layer");
-  
+
   // Transformer options
   cli.add<int>("--transformer-heads",
       "Number of heads in multi-head attention (transformer)",
@@ -725,6 +725,8 @@ void ConfigParser::addOptionsScoring(cli::CLIWrapper& cli) {
       "Paths to vocabulary files have to correspond to --train-sets. "
       "If this parameter is not supplied we look for vocabulary files source.{yml,json} and target.{yml,json}. "
       "If these files do not exists they are created");
+  cli.add<std::vector<std::string>>("--shortlist",
+     "Use softmax shortlist: path first best prune");
   cli.add<bool>("--n-best",
       "Score n-best list instead of plain text corpus");
   cli.add<std::string>("--n-best-feature",

--- a/src/data/shortlist.h
+++ b/src/data/shortlist.h
@@ -25,10 +25,11 @@ bool isBinaryShortlist(const std::string& fileName);
 class Shortlist {
 private:
   std::vector<WordIndex> indices_;    // // [packed shortlist index] -> word index, used to select columns from output embeddings
+  bool scoring_;                      ///< whether this shortlist is used in (re)scoring
 
 public:
   Shortlist(const std::vector<WordIndex>& indices)
-    : indices_(indices) {}
+    : indices_(indices), scoring_(false) {}
 
   const std::vector<WordIndex>& indices() const { return indices_; }
   WordIndex reverseMap(int idx) { return indices_[idx]; }
@@ -40,6 +41,15 @@ public:
     else
       return -1;                                          // return -1 if not found
   }
+
+  /**
+   * Set the operating mode of shortlist.
+   * When set to scoring mode, the shortlist retains the full-vocabulary, in the
+   * usual decoding mode, the vocabulary is restricted to shortlist indices.
+   * @param is_scoring whether or not the shortlist is used for scoring.
+   */
+  void isScoring(bool is_scoring) { scoring_ = is_scoring; }
+  bool isScoring() const { return scoring_; }
 };
 
 class ShortlistGenerator {

--- a/src/graph/expression_operators.cpp
+++ b/src/graph/expression_operators.cpp
@@ -688,6 +688,20 @@ Expr cross_entropy(Expr logits, Expr indices, float labelSmoothingAlpha, Type ou
   return Expression<CrossEntropyNodeOp>(logits, indices, labelSmoothingAlpha, outputType);
 }
 
+Expr cross_entropy_shortlist(Expr logits,
+                             Expr indices,
+                             Expr shortlist_indices,
+                             float labelSmoothingAlpha,
+                             Type outputType) {
+  int dimBatch = logits->shape()[-2];
+  int dimTime  = logits->shape()[-3];
+
+  auto indicesWithLayout = reshape(indices, {1, dimTime, dimBatch, 1});
+  auto shortlist_lse = logsumexp(index_select(logits, -1, shortlist_indices), -1);
+
+  return gather(shortlist_lse - logits, -1, indicesWithLayout);
+}
+
 // Unlikelihood loss based on https://arxiv.org/abs/1908.04319
 Expr unlikelihood(Expr logits, Expr indices) {
   int dimBatch = logits->shape()[-2];

--- a/src/graph/expression_operators.h
+++ b/src/graph/expression_operators.h
@@ -101,7 +101,7 @@ Expr get(Expr2 tuple) { return std::get<I>(tuple); }
 // by default, outputs are ordered.
 Expr2 topk(Expr a, int k, int axis, bool descending = true);
 
-// Convenience operator that maps to topk(a, k=1, axis, descending=true) 
+// Convenience operator that maps to topk(a, k=1, axis, descending=true)
 Expr2 argmax(Expr a, int axis);
 
 // Convenience operator that maps to topk(a, k=1, axis, descending=false)
@@ -265,6 +265,7 @@ Expr softmax(Expr a, Expr zeroOneMask, int axis = -1);
 Expr logsoftmax(Expr a);
 
 Expr cross_entropy(Expr a, Expr b, float labelSmoothingAlpha = 0.f, Type outputType = Type::float32);
+Expr cross_entropy_shortlist(Expr logits, Expr indices, Expr shortlist_indices, float labelSmoothingAlpha = 0.f, Type outputType = Type::float32);
 
 Expr unlikelihood(Expr a, Expr b);
 

--- a/src/layers/loss.h
+++ b/src/layers/loss.h
@@ -278,6 +278,7 @@ Ptr<MultiRationalLoss> newMultiLoss(Ptr<Options> options);
 class LabelwiseLoss {
 protected:
   std::vector<int> axes_;
+  Expr subset_;  //< enables loss to apply operations over a subset of values
 
   virtual Expr compute(Logits logits, const Words& labels,
                        Expr mask = nullptr, Expr labelWeights = nullptr) = 0;
@@ -311,8 +312,12 @@ protected:
   }
 
 public:
-  LabelwiseLoss(const std::vector<int>& axes)
-  : axes_(axes) { }
+  LabelwiseLoss(const std::vector<int>& axes) : axes_(axes), subset_(nullptr) {}
+
+  /**
+   * Define a subset to consider while computing loss
+   */
+  virtual void setSubset(Expr s) { subset_ = s; }
 
   virtual RationalLoss apply(Logits logits, const Words& labels,
                              Expr mask = nullptr, Expr labelWeights = nullptr) {
@@ -350,9 +355,15 @@ protected:
       logits = atleast_3d(logits); // we always assume a time and batch dimension exists.
       // for bert training or classification the time dimension is lost.
       // Here safeguard against 2d classifier output, adds 1 on the left, non-op.
-      
-      Expr ce = cross_entropy(logits, indices, inFactor ? 0.f : labelSmoothing_, Type::float32);
-      if (inFactor && factorWeight_ != 1.0f) {
+      Expr ce;
+      if(subset_){
+        ce = cross_entropy_shortlist(
+            logits, indices, subset_, inFactor ? 0.f : labelSmoothing_, Type::float32);
+      }
+      else {
+        ce = cross_entropy(logits, indices, inFactor ? 0.f : labelSmoothing_, Type::float32);
+      }
+      if(inFactor && factorWeight_ != 1.0f) {
         LOG_ONCE(info, "scaling factor losses with weight {}", factorWeight_);
         ce = ce * factorWeight_;
       }

--- a/src/models/costs.h
+++ b/src/models/costs.h
@@ -71,6 +71,12 @@ public:
     // multi-objective training
     Ptr<MultiRationalLoss> multiLoss = newMultiLoss(options_);
 
+    // When scoring (cost-type is ce-rescore) and a shortlist is available
+    if(encdec->getShortlist() && options_->get<std::string>("cost-type", "") == "ce-rescore") {
+      LOG(info, "Shortlist in costs.");
+      loss_->setSubset(graph->indices(encdec->getShortlist()->indices()));
+    }
+
     // @TODO: adapt to multi-objective training with multiple decoders
     auto partialLoss = loss_->apply(state->getLogProbs(),
                                     state->getTargetWords(),

--- a/src/models/decoder.h
+++ b/src/models/decoder.h
@@ -45,7 +45,7 @@ public:
         subBatch->data();
 #endif
 
-    ABORT_IF(shortlist_, "How did a shortlist make it into training?");
+    if(shortlist_){ LOG(debug, "Decode with shortlist set."); }
 
     auto yDelayed = shift(y, {1, 0, 0}); // insert zero at front; first word gets predicted from a target embedding of 0
 

--- a/src/models/model_base.h
+++ b/src/models/model_base.h
@@ -14,6 +14,21 @@ enum struct usage { raw, training, scoring, translation, embedding };
 
 YAML_REGISTER_TYPE(marian::models::usage, int)
 
+// 'FASTOPT_REGISTER_TYPE'
+#if FASTOPT
+namespace marian {
+namespace fastopt_helpers {
+
+template <>
+struct As<marian::models::usage> {
+  static marian::models::usage apply(const FastOpt& node) {
+    return static_cast<marian::models::usage>(As<int>::apply(node));
+  }
+};
+}  // namespace fastopt_helpers
+}  // namespace marian
+#endif
+
 namespace marian {
 namespace models {
 

--- a/src/models/transformer.h
+++ b/src/models/transformer.h
@@ -8,6 +8,7 @@
 #include "layers/constructors.h"
 #include "models/decoder.h"
 #include "models/encoder.h"
+#include "models/model_base.h"
 #include "models/states.h"
 #include "models/transformer_factory.h"
 #include "rnn/constructors.h"
@@ -862,10 +863,13 @@ public:
     //************************************************************************//
 
     // final feed-forward layer (output)
-    if(shortlist_)
+    if(shortlist_){
+      models::usage use = options_->get<models::usage>("usage", models::usage::translation);
+      shortlist_->isScoring(use == models::usage::scoring);
       output_->setShortlist(shortlist_);
+    }
     auto logits = output_->applyAsLogits(decoderContext); // [-4: beam depth=1, -3: max length, -2: batch size, -1: vocab or shortlist dim]
-    
+
     // return unormalized(!) probabilities
     Ptr<DecoderState> nextState;
     if (opt<std::string>("transformer-decoder-autoreg", "self-attention") == "rnn") {

--- a/src/rescorer/rescorer.h
+++ b/src/rescorer/rescorer.h
@@ -38,6 +38,17 @@ public:
     auto model = std::static_pointer_cast<models::Trainer>(builder_)->getModel();
     return std::static_pointer_cast<IEncoderDecoder>(model)->getAlignment();
   }
+
+  void setShortlistGenerator(Ptr<const data::ShortlistGenerator> shortlistGenerator) {
+    auto model = std::static_pointer_cast<models::Trainer>(builder_)->getModel();
+    return std::static_pointer_cast<IEncoderDecoder>(model)->setShortlistGenerator(
+        shortlistGenerator);
+  }
+
+  Ptr<data::Shortlist> getShortlist() {
+    auto model = std::static_pointer_cast<models::Trainer>(builder_)->getModel();
+    return std::static_pointer_cast<IEncoderDecoder>(model)->getShortlist();
+  }
 };
 
 template <class Model>
@@ -47,6 +58,7 @@ private:
   Ptr<CorpusBase> corpus_;
   std::vector<Ptr<ExpressionGraph>> graphs_;
   std::vector<Ptr<Model>> models_;
+  Ptr<const data::ShortlistGenerator> shortlistGenerator_;
 
 public:
   Rescore(Ptr<Options> options) : options_(options) {
@@ -65,6 +77,22 @@ public:
     else
       corpus_ = New<Corpus>(options_);
     corpus_->prepare();
+
+    auto srcVocab = corpus_->getVocabs().front();
+    auto trgVocab_ = corpus_->getVocabs().back();
+
+    std::vector<int> lshOpts{};
+    if(lshOpts.size() == 2 || options_->hasAndNotEmpty("shortlist")) {
+      auto slOptions = options_->get<std::vector<std::string>>("shortlist");
+      ABORT_IF(slOptions.empty(), "No path to shortlist file given");
+      std::string filename = slOptions[0];
+      if(data::isBinaryShortlist(filename))
+        shortlistGenerator_ = New<data::BinaryShortlistGenerator>(
+          options_, srcVocab, trgVocab_, 0, 1, srcVocab == trgVocab_);
+      else
+        shortlistGenerator_ = New<data::LexicalShortlistGenerator>(
+          options_, srcVocab, trgVocab_, 0, 1, srcVocab == trgVocab_);
+    }
 
     auto devices = Config::getDevices(options_);
 
@@ -87,6 +115,7 @@ public:
       pool.enqueue(
           [=](size_t j) {
             models_[j] = New<Model>(options_);
+            models_[j]->setShortlistGenerator(shortlistGenerator_);
             models_[j]->load(graphs_[j], modelFile);
           },
           i);


### PR DESCRIPTION
### Description

<details>
<summary>NOTE!</summary>

#### Motivation
This is a port of PR #2 on to the browsermt fork of marian.
This is necessary to use models that require intgemm.

#### Caveats
  1. `--gemm-precision int8shiftAlphaAll` currently doesn't work with `marian-scorer`; `int8`, `int8shift` do however. The problem is related to the loading of the precomputed alphas. Work is ongoing here.

---
</details>

This PR adds the possibility to use shortlist during (re)scoring in Marian Scorer. Its aim is to achieve word-scores from marian-scorer which are comparable to those obtained during decoding.

During decoding, tensor indices corresponding to non-shortlist tokens are discarded. This reduction in tensor size reduces the computational cost of later computations, and improves decoder performance. As such, the softmax+cross-entropy operation only ever sees shortlisted tokens. In order to imitate this in marian-rescorer, we perform a modified softmax which has a normalisation factor calculated from the sum of the subset defined by the shortlist. The sum of shortlist-only is correctly normalised to unity, while the sum over the full vocabulary is greater than (or equal to) unity. When we encounter tokens in scoring that are not in the shortlist, their value is not bounded above by 0, and therefore, may be positive.

**You must maintain the same batching as used in decoding!** The size of the generated shortlist depends on the contents of a particular batch, specifically the different tokens it contains. 

For performance, the cross-entropy operation in Marian implements the softmax sum as part of it's node operation. This implementation is different, and uses several node operations to accomplish its result. 

Finally, decoding and Scoring are two distinct modes of operation, utilising different code paths and therefore expression graphs, with decoder generating tokens sequentially, and scorer having them provided ahead of time. As such, floating point errors will propagate differently, and results _may_ be numerically different.

Added dependencies: none

### How to test
Using the same shortlist settings (e.g. `--shortlist lex.s2t.gz 100 100`), you should receive a roughly similar word-score when rescoring on decoder output.


### Checklist

- [ ] I have tested the code manually
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
